### PR TITLE
[fix] verify that ledger is not undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,7 +318,8 @@ Client.prototype._getAndHandlePaymentStatus =
     }
 
     if (response &&
-        (response.state === 'validated' || response.state === 'failed')) {
+        (response.state === 'validated' || response.state === 'failed') &&
+        (response.ledger != 'undefined')) {
       callback(null, response);
     } else {
       setTimeout(function() {


### PR DESCRIPTION
Hi, I'm running ripple-rest-client v1.17.0-rc1 and ripple-rest v1.6.0-rc1.

The _getAndHandlePaymentStatus does not take into account this case:  

{"success":true,"payment":{"source_account":"rGYZC2qMSDseEsK52Ta6JmgMA4ksGyM99V","source_tag":"","source_amount":{"currency":"DNX","value":"3702","issuer":"rfw73jNZHFZA3fPxwxguwUb6eR6yWfVCKf"},"source_slippage":"0","destination_account":"rG3YV5kDM6SvLHf35tParhBzi1mVPLPUnj","destination_tag":"3912171743","destination_amount":{"currency":"DNX","value":"3702","issuer":"rfw73jNZHFZA3fPxwxguwUb6eR6yWfVCKf"},"invoice_id":"","paths":"[]","no_direct_ripple":false,"partial_payment":false,"direction":"outgoing","timestamp":"","fee":"0.012","balance_changes":[],"source_balance_changes":[],"destination_balance_changes":[],"order_changes":[]},"client_resource_id":"995d17d0-20c3-47c2-92d8-c2ef343cf48d","hash":"B5717D1BB52CA6470996154D7101F9297A8F3FC29F10260DF5505906CBE15381","ledger":"undefined","state":"failed"}  

As you can see the ledger in undefined, and therefore the state failed, even though the payment was succesfull.
I slightly modified _getAndHandlePaymentStatus in order to solve it.
